### PR TITLE
Codium の削除

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -183,9 +183,6 @@ alias freeze='freeze --show-line-numbers --window'
 # emacs no-window
 #alias emacs='emacs -nw'
 
-# VSCodium alias
-alias code='codium'
-
 # Eza Alias (better ls)
 # alias ls="eza --color=always --long --git --no-filesize --icons=always --no-time --no-user --no-permissions"
 


### PR DESCRIPTION
GitHub Action, GitHub Copilot を使用するため、VSCodiujmから、VSCodeへ移行

これは敗北ではない