### PR TITLE
Forkのaliasコマンドを追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -52,6 +52,10 @@ alias cg='code ~/.gitconfig && source ~/.gitconfig'
 # Coteditor
 alias cot="open -a /Applications/CotEditor.app"
 
+# fork alias
+alias fork="open -a /Applications/Fork.app"
+
+
 # Create SwiftCLI(SPM)
 alias createSwiftCLI='swift package init  --type executable --name'
 


### PR DESCRIPTION
Git クライアントツールである[Fork](https://git-fork.com/)をターミナルで起動できるように、alias を追加しました。

Added alias so that [Fork](https://git-fork.com/), a Git GUI client tool, can be launched in the terminal.
