### PR TITLE
Claude Codeのステータスライン設定を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,6 @@
-{}
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh /Users/kaitomuraoka/.claude/statusline-command.sh"
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,8 @@
   "statusLine": {
     "type": "command",
     "command": "sh $HOME/.claude/statusline-command.sh"
+  },
+  "enabledPlugins": {
+    "swift-lsp@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "sh /Users/kaitomuraoka/.claude/statusline-command.sh"
+    "command": "sh $HOME/.claude/statusline-command.sh"
   }
 }

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Claude Code ステータスライン設定スクリプト
+# robbyrussell テーマ風のプロンプトに Claude Code の情報を追加
+
+input=$(cat)
+
+# Claude Code の情報を取得
+model=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+dir=$(basename "$cwd")
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+# カレントディレクトリ表示
+printf "\033[36m%s\033[0m" "$dir"
+
+# Git ブランチ表示（利用可能な場合）
+git_branch=$(git -C "$cwd" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
+if [ -n "$git_branch" ]; then
+  printf " \033[33mgit:(\033[31m%s\033[33m)\033[0m" "$git_branch"
+fi
+
+# モデル表示
+printf " \033[35m[%s]\033[0m" "$model"
+
+# コンテキスト使用率表示（データがある場合）
+if [ -n "$used_pct" ]; then
+  used_int=$(echo "$used_pct" | cut -d'.' -f1)
+  if [ "$used_int" -ge 80 ]; then
+    printf " \033[31mctx:%s%%\033[0m" "$used_int"
+  elif [ "$used_int" -ge 50 ]; then
+    printf " \033[33mctx:%s%%\033[0m" "$used_int"
+  else
+    printf " \033[32mctx:%s%%\033[0m" "$used_int"
+  fi
+fi

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -33,3 +33,4 @@ if [ -n "$used_pct" ]; then
     printf " \033[32mctx:%s%%\033[0m" "$used_int"
   fi
 fi
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,15 @@ editor/.config/github-copilot/
 
 .config/nvim/
 .config/ghostty/
+
+# Claude Code（履歴・セッション情報）
+.claude/projects/
+.claude/history.jsonl
+.claude/.session-env/
+.claude/backups/
+.claude/cache/
+.claude/debug/
+.claude/mcp-needs-auth-cache.json
+.claude/plugins/
+.claude/shell-snapshots/
+.claude/todos/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ editor/.config/github-copilot/
 .claude/plugins/
 .claude/shell-snapshots/
 .claude/todos/
+.claude/file-history/


### PR DESCRIPTION
## 変更内容

Claude Code のステータスライン設定を追加した。

- `.claude/settings.json` にステータスライン設定を追加し、カスタムシェルスクリプトを実行するよう設定
- `.claude/statusline-command.sh` を新規作成。以下の情報をターミナルに表示する
  - カレントディレクトリ名（シアン）
  - Git ブランチ名（黄・赤）
  - 使用中モデル名（マゼンタ）
  - コンテキスト使用率（緑/黄/赤で段階的に色分け）
- `.gitignore` に Claude Code の履歴・セッション情報などを追加し、不要なファイルがリポジトリに含まれないよう除外設定

## 変更理由

Claude Code のセッション中に現在のモデルやコンテキスト使用状況をひと目で確認できるようにするため。特にコンテキスト使用率を色分け表示することで、コンテキスト上限への接近を視覚的に把握できる。

## 備考

- コンテキスト使用率は 50% 以上で黄、80% 以上で赤に変化する
- robbyrussell テーマ（zsh）風のスタイルに合わせたデザイン