### PR TITLE
fix(zshrc): GoのPATHをGOPATH/binに修正し、不要なエイリアスを削除

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -130,8 +130,7 @@ alias l="clear && ls"
 ## [/Completion]
 
 ## go
-export PATH=$PATH:/usr/local/go/bin
-alias fr="~/privateproduct/discipline-cli/frame"
+export PATH="$PATH:$(go env GOPATH)/bin"
 
 ## node nodebrew
 export PATH=$HOME/.nodebrew/current/bin:$PATH


### PR DESCRIPTION
## 変更内容

- GoのPATH設定を `/usr/local/go/bin` から `$(go env GOPATH)/bin` に変更
- 不要なエイリアス `fr` を削除

## 変更理由

- GoのPATH設定をハードコードされたパスではなく、`go env GOPATH` を使った動的な設定に変更することで、環境に依存しない設定にするため
- `fr` エイリアスはプライベートリポジトリのバイナリを参照しており、dotfilesに含める必要がないため削除

## 備考

- 特になし