### PR TITLE
fix(zshrc): Add Emacs vterm integration, fix fzf-fg keybinding, and add ~/.local/bin to PATH

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,6 +21,10 @@ source $ZSH/oh-my-zsh.sh
 # claude-code のバックグラウンドアップグレード（cask パッケージのため --cask が必要）
 (brew upgrade claude-code &>/dev/null &)
 
+if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+    source /Users/kaito.muraoka/.emacs.d/straight/repos/emacs-libvterm/etc/emacs-vterm-zsh.sh
+fi
+
 # the fuck
 eval "$(thefuck --alias)"
 
@@ -174,6 +178,7 @@ export PATH="$HOME/Library/Python/3.9/bin:$PATH"
 if ! pgrep -f "emacs.*--daemon" > /dev/null 2>&1; then
   /Applications/Emacs.app/Contents/MacOS/Emacs --daemon &>/dev/null &
 fi
+
 # Ctrl+j で中断ジョブを一覧から fzf で選んで fg する
 fzf-fg() {
   local job
@@ -184,3 +189,4 @@ fzf-fg() {
 zle -N fzf-fg
 bindkey '^J' fzf-fg
 
+export PATH="$HOME/.local/bin:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -187,6 +187,6 @@ fzf-fg() {
   zle reset-prompt
 }
 zle -N fzf-fg
-bindkey '^J' fzf-fg
+bindkey '\ej' fzf-fg
 
 export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary

- Add Emacs `vterm` shell integration: sources `emacs-vterm-zsh.sh` when running inside Emacs vterm, enabling directory tracking and other shell-side features
- Fix `fzf-fg` keybinding from `^J` (Ctrl+J) to `\ej` (Alt+J) to avoid conflict with Emacs terminal, where `C-j` is interpreted as Enter
- Add `~/.local/bin` to `PATH` to support tools installed by pipx and similar utilities

## Test plan

- [ ] Reload shell with `source ~/.zshrc` and verify no errors
- [ ] Open a terminal inside Emacs vterm and confirm shell integration works
- [ ] Press Alt+J with a suspended job and verify fzf job selector appears
- [ ] Confirm `pipx`-installed commands are accessible directly