### PR TITLE
chore(zshrc): vim を nvim にエイリアスし、Emacs.app のパスとエイリアスを追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -125,7 +125,7 @@ fpath+=${ZDOTDIR:-~}/.zsh_functions
 export PATH="$PATH:/Users/kaitomuraoka/.local/bin"
 
 # emacs alias
-alias emacsinit="cd ~/.emacs.d/ && emacs -nw init.el && emacs --batch -f batch-byte-compile init.el"
+alias emacs="/Applications/Emacs.app/Contents/MacOS/Emacs"
 
 # eza alias
 alias ei="eza --icons --git"
@@ -191,3 +191,4 @@ zle -N fzf-fg
 bindkey '\ej' fzf-fg
 
 export PATH="$HOME/.local/bin:$PATH"
+export PATH="/Applications/Emacs.app/Contents/MacOS/bin:$PATH"


### PR DESCRIPTION
## 変更内容

- `vim` コマンドを `nvim` のエイリアスとして追加
- `emacs` エイリアスを `/Applications/Emacs.app/Contents/MacOS/Emacs` に変更
- `Emacs.app` の bin ディレクトリを `PATH` に追加

## 変更理由

- `vim` を実行した際にも `nvim` が起動するようにし、エディタ操作を統一するため
- ターミナルから GUI 版 Emacs を直接起動できるようにし、Emacs.app 同梱のコマンド群も利用可能にするため

## 備考

- 旧 `emacsinit` エイリアスは削除済み