### PR TITLE
Update config

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -3,7 +3,7 @@
 	email = 70003919+KaitoMuraoka@users.noreply.github.com
 
 [core]
-    editor = emacsclient --nw
+    editor = emacsclient -c
 	excludesfile = ~/.gitignore_global
 
 # git delta config
@@ -29,6 +29,7 @@
     colorMoved = default
 
 [alias]
+  rebase-branch = "rebase -i $(git merge-base HEAD main)"
   emptycommit = "commit --allow-empty -m "空コミット""
   logo = "log --oneline"
   delete-merged-branch = "!f () { git checkout $1; git branch --merged|egrep -v '\\*|develop|main'|xargs git branch -d; };f"


### PR DESCRIPTION
# 課題
git rebase する時、ベースブランチのコミットも変更してしまう問題がある
それはとてもこわい

## 解決方法
現在のブランチの分岐点を基点に指定すれば、そのブランチのコミットだけが対象になる。
そのため、この対応を行った

```
main:   A - B - C
                 \
your-branch:      D - E - F  ← この3つだけ対象にしたい
```

git merge-base HEAD main が Cのハッシュを返すので、C以降（D, E, F）だけがrebase対象になります。
